### PR TITLE
Upgrade Go to version 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.26'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
@@ -28,6 +28,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.26'
       - name: Test
         run: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/pixelvide/laravel-go
 
-go 1.24.0
+go 1.26.0
 
-toolchain go1.24.3
+toolchain go1.26.0
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
Upgrade Go to version 1.26.x in CI workflow and go.mod. Also added toolchain in the go.mod file.

---
*PR created automatically by Jules for task [4392933286300800239](https://jules.google.com/task/4392933286300800239) started by @ngoyal16*